### PR TITLE
[fix] savefig & savedat bug due to API change when migrating to Python3

### DIFF
--- a/qt_stm3.py
+++ b/qt_stm3.py
@@ -151,9 +151,9 @@ class Form(QMainWindow):
                        'Save Data:', defaultDatName, '')
 
         if datName and self.STMData.size != 0:
-            xx = np.vstack((self.STMXCoord[np.newaxis, ...],
-                            self.STMYCoord[np.newaxis, ...],
-                            self.STMData[np.newaxis, ...]))
+            xx = np.vstack((self.STMXCoord,
+                            self.STMYCoord,
+                            self.STMData))
             np.savetxt(str(datName), xx)
     
     def GenerateData(self):

--- a/qt_stm3.py
+++ b/qt_stm3.py
@@ -133,24 +133,24 @@ class Form(QMainWindow):
 
     def save_img(self):
         if self.whicISO == 0:
-            defaultImgName = './STM_H_%d.png' % self.zcut
+            defaultImgName = f'./STM_H_{self.zcut}.png'
         else:
-            defaultImgName = './STM_C_%d.png' % self.zcut
+            defaultImgName = f'./STM_C_{self.zcut}.png'
 
-        imgName = QFileDialog.getSaveFileName(self,
+        imgName, _ = QFileDialog.getSaveFileName(self,
                        'Save Image:', defaultImgName, '')
         if imgName:
             self.fig.savefig(str(imgName), dpi=self.dpi)
 
     def save_dat(self):
         if self.whicISO == 0:
-            defaultDatName = './STM_H_%d_%dx%d.npy' % (self.zcut, self.repeat_x, self.repeat_y)
+            defaultDatName = './STM_H_{}_{}x{}.npy'.format(self.zcut, self.repeat_x, self.repeat_y)
         else:
-            defaultDatName = './STM_C_%d_%dx%d.npy' % (self.zcut, self.repeat_x, self.repeat_y)
-        datName = QFileDialog.getSaveFileName(self,
+            defaultDatName = './STM_C_{}_{}x{}.npy'.format(self.zcut, self.repeat_x, self.repeat_y)
+        datName, _ = QFileDialog.getSaveFileName(self,
                        'Save Data:', defaultDatName, '')
 
-        if datName and self.STMData:
+        if datName and self.STMData.size != 0:
             xx = np.vstack((self.STMXCoord[np.newaxis, ...],
                             self.STMYCoord[np.newaxis, ...],
                             self.STMData[np.newaxis, ...]))

--- a/qt_stm3.py
+++ b/qt_stm3.py
@@ -128,6 +128,7 @@ class Form(QMainWindow):
                 self.InfoLabs[irow][1].setText(u'%.2f \u212B' % self.VaspPchg.abc[irow])
             self.GenerateData()
             self.updateZV()
+        self.filename = None
 
 
     def save_img(self):


### PR DESCRIPTION
- `QFileDialog.getSaveFileName` returns a tuple `(fileName, selectedFilter)` rather than a single string.
- `np.vstack(twoDArray[np.newaxis, ...])` will produce a three-dimensional array, which cannot perform `np.savetxt()`.